### PR TITLE
fix(proxy): handle lowercase Location header

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -30,7 +30,7 @@ func createFasthttpClient(timeout int) *fasthttp.Client {
 		WriteTimeout:                  time.Duration(timeout) * time.Second,
 		MaxIdleConnDuration:           time.Duration(timeout) * time.Second,
 		MaxConnDuration:               time.Duration(timeout) * time.Second,
-		DisableHeaderNamesNormalizing: true,
+		DisableHeaderNamesNormalizing: false,
 	}
 }
 


### PR DESCRIPTION
When the upstream server returns a redirect HTTP response code but its "Location" header is in lowercase, the proxy will retry the request 5 times and eventually fail with an "missing Location header for http redirect" error.

Since the HTTP spec says header names are case-insensitive, we should handle this case properly. Adjust fasthttp options accordingly

Ref: https://github.com/valyala/fasthttp/issues/1361